### PR TITLE
fix community url for other language

### DIFF
--- a/templates/macros/body.html
+++ b/templates/macros/body.html
@@ -18,7 +18,7 @@
         <ul>
           <li><a href="{{ get_url(path='@/about/index.md', lang=lang) }}">{{ trans(key='about', lang=lang) }}</a></li>
             <li><a href="{{ config.extra.docs_url }}">{{ trans(key='documentation', lang=lang) }}</a></li>
-            <li><a href="{{ get_url(path='/') }}#community">{{ trans(key='community', lang=lang) }}</a></li>
+            <li><a href="{{ get_url(path='/', lang=lang) }}#community">{{ trans(key='community', lang=lang) }}</a></li>
             <li><a href="{{ get_url(path='@/blog/_index.md') }}">{{ trans(key='blog', lang=lang) }}</a></li>
             <li><a href="{{ config.extra.language_source_code_url }}">{{ trans(key='source_code', lang=lang) }}</a></li>
             <li><a href="{{ config.extra.wiki_url }}">{{ trans(key='wiki', lang=lang) }}</a></li>


### PR DESCRIPTION
In non-English languages, the URL for the `Community` should be `https://vala.dev/<lang>/#community`, but now it is `https://vala.dev/#community`