### PR TITLE
Remove redundant `target-glib` flag from code sample compile command

### DIFF
--- a/assets/code-sample.md
+++ b/assets/code-sample.md
@@ -23,5 +23,5 @@ public class ExampleApp : Gtk.Application {
 }
 
 // Compile command (requires gtk4 package to be installed):
-// valac --target-glib=auto --pkg gtk4 ExampleApp.vala
+// valac --pkg gtk4 ExampleApp.vala
 ```


### PR DESCRIPTION
From the [GLib source code](https://gitlab.gnome.org/GNOME/glib/-/blob/main/gio/gioenums.h#L1546), we can see that the correct default Application flag will be set by default:

```c
typedef enum /*< prefix=G_APPLICATION >*/
{
  G_APPLICATION_FLAGS_NONE GIO_DEPRECATED_ENUMERATOR_IN_2_74_FOR(G_APPLICATION_DEFAULT_FLAGS),
  G_APPLICATION_DEFAULT_FLAGS GIO_AVAILABLE_ENUMERATOR_IN_2_74 = 0,
...
```
