### PR TITLE
Update c-off-ramp.md

### DIFF
--- a/content/blog/c-off-ramp.md
+++ b/content/blog/c-off-ramp.md
@@ -1,6 +1,6 @@
 +++
 title = "Vala: the smoothest C off-ramp"
-date = "2024-04-13"
+date = "2024-04-22"
 description="Using Vala to rewrite old C code"
 
 [extra]


### PR DESCRIPTION
This is sadly needed, because a technical issue let the post on the original date not appear on planet gnome.